### PR TITLE
Leveraged Node to provide 0 to 100% uptime for React frontend, allowing all future users to access web application

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -3,12 +3,13 @@ FROM node:lts-alpine
 WORKDIR /app
 
 COPY package.json .
+COPY package-lock.json .
 
 RUN npm install --only-prod --force
 
-COPY ./src .
+COPY ./src ./src
 
-COPY ./public .
+COPY ./public ./public
 
 COPY .gitignore .
 
@@ -16,4 +17,4 @@ COPY tsconfig.json .
 
 EXPOSE 3000
 
-CMD ["npm", "start"]
+RUN node node_modules/react-scripts/bin/react-scripts.js start


### PR DESCRIPTION
# I am a big whale

Line 20 `RUN node node_modules/react-scripts/bin/react-scripts.js start` uses the raw path of react-scripts to begin the web application, what was happening before was that the Docker container couldn't run react-scripts because it couldn't find it